### PR TITLE
added php fpm rules to stop apache 500 errors

### DIFF
--- a/config/php5-fpm-config/www.conf
+++ b/config/php5-fpm-config/www.conf
@@ -41,9 +41,9 @@ listen = /var/run/php5-fpm.sock
 ; BSD-derived systems allow connections regardless of permissions. 
 ; Default Values: user and group are set as the running user
 ;                 mode is set to 0666
-;listen.owner = www-data
-;listen.group = www-data
-;listen.mode = 0666
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0666
  
 ; List of ipv4 addresses of FastCGI clients which are allowed to connect.
 ; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original


### PR DESCRIPTION
When running this for the first time, or after doing an apt-get update in the vagrant vm, apache errors out due to fpm problems.

By uncommenting these lines, it works again.

After some research, seems like it has to do with this bug. https://bugs.php.net/bug.php?id=67060
